### PR TITLE
Remove non-essential VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,20 +1,10 @@
 {
   "recommendations": [
-    "christian-kohler.npm-intellisense",
-    "christian-kohler.path-intellisense",
-    "coenraads.bracket-pair-colorizer",
     "dbaeumer.vscode-eslint",
-    "dbaeumer.vscode-eslint",
-    "eamodio.gitlens",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
-    "formulahendry.auto-close-tag",
     "jpoissonnier.vscode-styled-components",
-    "orta.vscode-jest",
-    "pnp.polacode",
-    "tombonnike.vscode-status-bar-format-toggle",
-    "wayou.vscode-todo-highlight",
-    "yzhang.markdown-all-in-one"
+    "tombonnike.vscode-status-bar-format-toggle"
   ],
   "unwantedRecommendations": []
 }


### PR DESCRIPTION
Remove them from the extensions recommendation
Solves #8 