### PR TITLE
Fix an issue caused by dynamically importing react-axe without accessing the default property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const container = document.getElementById('root')
 
 if (process.env.NODE_ENV !== 'production') {
   import('react-axe').then(axe => {
-    axe(React, ReactDOM, 1000)
+    axe.default(React, ReactDOM, 1000)
     ReactDOM.render(ui, container)
   })
 } else {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6315466/63988005-ccf27a80-cb0c-11e9-932c-1600844693cf.png)
